### PR TITLE
rename Analysis to Zone

### DIFF
--- a/backend/src/models/Zone.ts
+++ b/backend/src/models/Zone.ts
@@ -1,6 +1,6 @@
 import { model, Schema } from 'mongoose';
 
-const analysisSchema = new Schema(
+const zoneSchema = new Schema(
   {
     bbox: {
       type: [Number],
@@ -54,4 +54,4 @@ const analysisSchema = new Schema(
   }
 );
 
-export default model('Analysis', analysisSchema);
+export default model('Zone', zoneSchema);

--- a/backend/src/models/index.ts
+++ b/backend/src/models/index.ts
@@ -1,1 +1,1 @@
-export { default as Analysis } from './Analysis.ts';
+export { default as Zone } from './Zone.ts';

--- a/backend/src/schemas/index.ts
+++ b/backend/src/schemas/index.ts
@@ -1,1 +1,1 @@
-export * from './analysis.ts';
+export * from './zone.ts';

--- a/backend/src/schemas/zone.ts
+++ b/backend/src/schemas/zone.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod/v4';
 import { Types } from 'mongoose';
 
-export const analysisInputSchema = z.strictObject({
+export const zoneInputSchema = z.strictObject({
   bbox: z
     .array(z.number({ error: 'Bounding box must contain only numbers' }))
     .length(4, { message: 'Bounding box must have exactly 4 numbers' }),
@@ -21,9 +21,9 @@ export const analysisInputSchema = z.strictObject({
   aiText: z.string({ error: 'AI text must be a string' }).optional()
 });
 
-export const analysisSchema = z.strictObject({
+export const zoneSchema = z.strictObject({
   _id: z.instanceof(Types.ObjectId),
-  ...analysisInputSchema.shape,
+  ...zoneInputSchema.shape,
   createdAt: z.date(),
   updatedAt: z.date(),
   __v: z.number()


### PR DESCRIPTION
Renamed the Analysis mongoose model and Zod schemas to Zone to better
represent the concept of a processed geographic region with metrics
and AI text.